### PR TITLE
xrpchina rename

### DIFF
--- a/src/assets/gateways.json
+++ b/src/assets/gateways.json
@@ -72,7 +72,7 @@
             "hotwallets": []
             }]
     }, {
-        "name": "XRPChina",
+        "name": "DotPayco",
         "startDate": "2013-06-02",
         "accounts": [{
             "address": "rM8199qFwspxiWNZRChZdZbGN5WrCepVP1",


### PR DESCRIPTION
I‘m a xrpchina's developer.
 We are now renamed as dotpayco, but due to our negligence, did not retain xrpchina register name, and this name is register by other.

please accept this pull request