### PR TITLE
Improved txsplain phrasing for TrustSet

### DIFF
--- a/src/common/txsplain.js
+++ b/src/common/txsplain.js
@@ -410,8 +410,8 @@ var base64Match = new RegExp('^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-
         function renderTrustSet(tx) {
           return 'It establishes <b>' + commas(tx.tx.LimitAmount.value) + '</b>' +
             ' as the maximum amount of ' + tx.tx.LimitAmount.currency +
-            ' that <account>' + tx.tx.Account + '</account> allows to be ' +
-            ' held by <account>' + tx.tx.LimitAmount.issuer + '</account>.';
+            ' from <account>' + tx.tx.LimitAmount.issuer + '</account>' +
+            ' that <account>' + tx.tx.Account + '</account> is willing to hold.';
         }
 
         function renderPayment(tx) {


### PR DESCRIPTION
The current transaction explainer has a misleading message for TrustSet transactions. For example:
> It establishes 10,000,000 as the maximum amount of XLM that rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6 allows to be held by ~ripplefox (rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y).

I haven't tested this code, but it should change the message to be clearer. For example:
> It establishes 10,000,000 as the maximum amount of XLM from ~ripplefox (rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y) that rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6 is willing to hold.