### PR TITLE
txsplain edits for EnableAmendment, etc.

### DIFF
--- a/src/less/txsplain.less
+++ b/src/less/txsplain.less
@@ -84,6 +84,11 @@ txsplain {
     color: darkgreen;
   }
 
+  amendment_id {
+    font-weight: bold;
+    color: #337ab7;
+  }
+
   .meta ul {
     display:block;
     padding-left: 30px;


### PR DESCRIPTION
- Fixes time zone discrepancy in dates parsed from different formats
- Differentiates transactions from pseudo-transactions
- Adds custom descriptor for EnableAmendment pseudo-tx:
    - Indicates whether the tx represents gaining a majority, losing a majority, or enabling an amendment
    - For the majority-gained case, estimates when the amendment will become enabled