### PR TITLE
Index - capitalize GitHub

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -215,7 +215,7 @@
             &middot;
             <a href="https://ripple.com/terms-of-use/" target="_blank">Terms of Service</a>
             &middot;
-            <a href="https://github.com/ripple/ripplecharts-frontend" target="_blank">Github</a>
+            <a href="https://github.com/ripple/ripplecharts-frontend" target="_blank">GitHub</a>
             &middot;
             <span class="version">v<%= version %></span>
           </div>


### PR DESCRIPTION
["Git" and "Hub" are both officially capitalized](https://github.com/about), suggest doing so here.